### PR TITLE
feat: Add richer visual effects to portfolio page

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,6 +168,13 @@
             color: inherit;
         }
 
+        /* Hero Section Keyframes */
+        @keyframes animateHeroBackground {
+            0% { background-position: 0% 50%; }
+            50% { background-position: 100% 50%; }
+            100% { background-position: 0% 50%; }
+        }
+
         /* Hero Section */
         .hero {
             height: 100vh;
@@ -179,7 +186,10 @@
             padding: 0 10%;
             position: relative;
             overflow: hidden;
-            background-color: #000;
+            /* background-color: #000; */ /* Replaced by animated gradient */
+            background: linear-gradient(270deg, #0a0a0a, #1a1a1d, #0a0a0a, #2c2c34);
+            background-size: 400% 400%;
+            animation: animateHeroBackground 20s ease infinite;
             color: var(--light-color);
         }
 
@@ -481,6 +491,14 @@
             display: inline-block;
             padding-bottom: 15px;
             counter-increment: section-counter;
+            opacity: 0; /* Initial state for scroll reveal */
+            transform: translateY(30px); /* Initial state for scroll reveal */
+            transition: opacity 0.8s ease-out, transform 0.8s ease-out; /* Animation */
+        }
+
+        .section-heading h2.reveal-visible {
+            opacity: 1; /* Visible state */
+            transform: translateY(0); /* Visible state */
         }
 
         .section-heading h2::after {
@@ -525,7 +543,7 @@
         .about-img img {
             width: 100%;
             display: block;
-            transition: transform 5s linear;
+            /* transition: transform 5s linear; */ /* Removed: JS handles parallax transform */
         }
 
         .about-text {
@@ -592,6 +610,7 @@
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
             gap: 40px;
+            perspective: 1000px; /* Add perspective for 3D effect */
         }
 
         .project-card {
@@ -599,7 +618,9 @@
             border-radius: 20px;
             overflow: hidden;
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
-            transition: all 0.5s cubic-bezier(0.215, 0.61, 0.355, 1);
+            transition: transform 0.5s cubic-bezier(0.215, 0.61, 0.355, 1), 
+                        box-shadow 0.5s cubic-bezier(0.215, 0.61, 0.355, 1),
+                        opacity 0.5s ease; /* Updated transition */
             position: relative;
         }
 
@@ -617,7 +638,7 @@
         }
 
         .project-card:hover {
-            transform: translateY(-10px);
+            transform: translateY(-10px) rotateX(3deg) rotateY(-3deg); /* Added 3D tilt */
             box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
         }
 
@@ -681,12 +702,29 @@
             border-radius: 50px;
             font-size: 0.9rem;
             font-weight: 500;
-            transition: all 0.3s ease;
+            transition: all 0.3s ease; /* Keep existing transitions */
+            position: relative; /* Needed for pseudo-element positioning */
+            overflow: hidden; /* To hide underline overflow */
+        }
+
+        .project-links a::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: -100%; /* Start from outside left */
+            width: 100%;
+            height: 2px;
+            background-color: var(--accent-color); /* Use accent color for underline */
+            transition: left 0.4s cubic-bezier(0.215, 0.61, 0.355, 1);
         }
 
         .project-links a:hover {
-            background-color: #0071e3;
-            transform: translateY(-2px);
+            background-color: #0071e3; /* Keep existing background change for non-view buttons */
+            transform: translateY(-2px); /* Keep existing translateY */
+        }
+
+        .project-links a:hover::after {
+            left: 0; /* Animate underline in */
         }
 
         .project-links a.view {
@@ -696,8 +734,12 @@
         }
 
         .project-links a.view:hover {
-            background-color: var(--secondary-color);
-            color: white;
+            background-color: var(--secondary-color); /* Keep existing background change */
+            color: white; /* Keep existing text color change */
+        }
+        
+        .project-links a.view:hover::after {
+            background-color: white; /* Change underline color for view button on hover */
         }
 
         /* Contact Section */
@@ -814,7 +856,7 @@
         .social-links a:hover {
             background-color: var(--secondary-color);
             color: white;
-            transform: translateY(-5px);
+            transform: translateY(-5px) scale(1.15); /* Added scale effect */
         }
 
         /* Footer */
@@ -961,6 +1003,22 @@
                 width: 45px;
                 height: 45px;
             }
+        }
+
+        /* Skill Tag Animation */
+        @keyframes slideInFadeIn {
+            from {
+                opacity: 0;
+                transform: translateY(20px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .skill-tag.animate-in {
+            animation: slideInFadeIn 0.5s ease-out forwards;
         }
     </style>
 </head>
@@ -1346,6 +1404,82 @@
                 // Here you would normally send the form data to a server
                 alert('Thank you for your message! I will get back to you soon.');
                 this.reset();
+            });
+        }
+
+        // About Me Image Parallax
+        const aboutImg = document.querySelector('.about-img img');
+        if (aboutImg) {
+            window.addEventListener('scroll', function() {
+                const scrollY = window.pageYOffset;
+                const aboutSection = document.querySelector('.about');
+                if (aboutSection) {
+                    const sectionTop = aboutSection.offsetTop;
+                    const sectionHeight = aboutSection.offsetHeight;
+                    const imgHeight = aboutImg.offsetHeight;
+                    
+                    // Check if the about section is in view
+                    if (scrollY > sectionTop - window.innerHeight && scrollY < sectionTop + sectionHeight) {
+                        // Calculate the parallax effect only when the image is roughly in the viewport
+                        // Adjust the '0.1' factor to control the speed/subtlety of the parallax
+                        const parallaxValue = (scrollY - (sectionTop - window.innerHeight / 2)) * 0.1;
+                        // Limit the parallax effect to prevent the image from moving too far
+                        const maxParallax = imgHeight * 0.2; // Max 20% of image height
+                        const limitedParallaxValue = Math.max(-maxParallax, Math.min(maxParallax, parallaxValue));
+                        aboutImg.style.transform = `translateY(${limitedParallaxValue}px)`;
+                    }
+                }
+            });
+        }
+
+        // Skill Tag Animation with Intersection Observer
+        const skillTags = document.querySelectorAll('.skill-tag');
+        if (skillTags.length > 0) {
+            const observerOptions = {
+                root: null, // viewport
+                rootMargin: '0px',
+                threshold: 0.1 // Trigger when 10% of the element is visible
+            };
+
+            const observerCallback = (entries, observer) => {
+                entries.forEach((entry, index) => {
+                    if (entry.isIntersecting) {
+                        // Add a staggered delay
+                        setTimeout(() => {
+                            entry.target.classList.add('animate-in');
+                        }, index * 100); // 100ms delay between each tag
+                        observer.unobserve(entry.target); // Stop observing once animated
+                    }
+                });
+            };
+
+            const skillsObserver = new IntersectionObserver(observerCallback, observerOptions);
+            skillTags.forEach(tag => {
+                skillsObserver.observe(tag);
+            });
+        }
+
+        // Section Heading Scroll Reveal Animation
+        const sectionHeadings = document.querySelectorAll('.section-heading h2');
+        if (sectionHeadings.length > 0) {
+            const revealObserverOptions = {
+                root: null, // viewport
+                rootMargin: '0px',
+                threshold: 0.1 // Trigger when 10% of the element is visible
+            };
+
+            const revealObserverCallback = (entries, observer) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add('reveal-visible');
+                        observer.unobserve(entry.target); // Stop observing once animated
+                    }
+                });
+            };
+
+            const headingsObserver = new IntersectionObserver(revealObserverCallback, revealObserverOptions);
+            sectionHeadings.forEach(heading => {
+                headingsObserver.observe(heading);
             });
         }
     </script>


### PR DESCRIPTION
This commit introduces several new visual effects and enhances existing ones across the portfolio page to create a more dynamic and engaging user experience.

Enhancements include:

-   **About Me Section:**
    -   Added a subtle parallax scrolling effect to the profile image.
    -   Skill tags now animate (slide in and fade) when they scroll into view, with a slight stagger.

-   **Featured Projects Section:**
    -   Project cards now have a subtle 3D tilt effect on hover, in addition to existing effects.
    -   Project links ("View Github", "Live Site") feature an animated underline on hover for better interactivity.

-   **Contact Section:**
    -   Social media icons now scale up slightly on hover for a more pronounced effect.

-   **Hero Section:**
    -   The hero section background now features a subtle, slow-moving animated dark gradient.

-   **General:**
    -   Section headings (e.g., "About Me", "Featured Projects") now animate (fade in and slide up) as they scroll into view.

All effects have been reviewed for consistency, subtlety, and performance considerations. Animations primarily leverage CSS transforms and opacity, and Intersection Observers are used for scroll-triggered animations to optimize performance.